### PR TITLE
fix: kind-install directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,7 @@ kind: # Create a kind cluster
 kind-install: # Install the controller in the kind cluster
 	@if [ ! -x $(LOCALBIN)/kind ]; then \
 		echo "kind not installed. Installing..."; \
+		mkdir -p $(LOCALBIN); \
 		if [ $$(uname) = "Linux" ]; then \
 			[ $$(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.22.0/kind-linux-amd64; \
 			[ $$(uname -m) = aarch64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.22.0/kind-linux-arm64; \
@@ -259,7 +260,7 @@ kind-install: # Install the controller in the kind cluster
 			[ $$(uname -m) = arm64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.22.0/kind-darwin-arm64; \
 		fi; \
 		chmod +x ./kind; \
-		sudo mv ./kind $(LOCALBIN)/kind; \
+		mv ./kind $(LOCALBIN)/kind; \
 	fi
 
 .PHONY: kind-delete

--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ kind-install: # Install the controller in the kind cluster
 			[ $$(uname -m) = arm64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.22.0/kind-darwin-arm64; \
 		fi; \
 		chmod +x ./kind; \
-		mv ./kind $(LOCALBIN)/kind; \
+		sudo mv ./kind $(LOCALBIN)/kind; \
 	fi
 
 .PHONY: kind-delete


### PR DESCRIPTION
On clean install, was getting a "directory" not exist when doing make kind-install.  this will create directory before moving kind